### PR TITLE
More accurate offset when calculating velocity

### DIFF
--- a/zipline.inc
+++ b/zipline.inc
@@ -398,7 +398,7 @@ _zipline_exit(playerid) {
 	SetPlayerVelocity(playerid,
 		zip_Data[tmpid][zip_vecX] * zip_PlayerSpeedMult[playerid],
 		zip_Data[tmpid][zip_vecY] * zip_PlayerSpeedMult[playerid],
-		(zip_Data[tmpid][zip_vecZ] + 0.05) * zip_PlayerSpeedMult[playerid]);
+		(zip_Data[tmpid][zip_vecZ] + 0.03) * zip_PlayerSpeedMult[playerid]);
 
 	stop zip_UpdateTimer[playerid];
 
@@ -436,7 +436,7 @@ timer ZiplineUpdate[50](playerid) {
 	SetPlayerVelocity(playerid,
 		zip_Data[zip_currentZipline[playerid]][zip_vecX] * zip_PlayerSpeedMult[playerid],
 		zip_Data[zip_currentZipline[playerid]][zip_vecY] * zip_PlayerSpeedMult[playerid],
-		(zip_Data[zip_currentZipline[playerid]][zip_vecZ] + 0.05) * zip_PlayerSpeedMult[playerid]);
+		(zip_Data[zip_currentZipline[playerid]][zip_vecZ] + 0.03) * zip_PlayerSpeedMult[playerid]);
 
 	if(zip_PlayerSpeedMult[playerid] < 0.5) {
 		zip_PlayerSpeedMult[playerid] += 0.01;


### PR DESCRIPTION
0.05 was too much and the player went too up on long ziplines causing them to exit them and fall. After playing a bit with the values, I was surprised by how amazingly accurate 0.03 was, even for upwards ziplines. I've seen 0.03 on some places before so this is probably some known offset too.